### PR TITLE
Add data grid to IssueBrowse component

### DIFF
--- a/src/MaelstromPlatform.API/Issue/IIssueRepository.cs
+++ b/src/MaelstromPlatform.API/Issue/IIssueRepository.cs
@@ -3,6 +3,7 @@
     public interface IIssueRepository
     {
         Task<IEnumerable<IssueEntity>> GetAllIssuesAsync();
+        Task<IssueEntity> GetIssueByIdAsync(Guid id);
         Task<bool> SaveChangesAsync();
     }
 }

--- a/src/MaelstromPlatform.API/Issue/IssueForGetByIdDto.cs
+++ b/src/MaelstromPlatform.API/Issue/IssueForGetByIdDto.cs
@@ -1,9 +1,15 @@
-﻿namespace MaelstromPlatform.UI.Components.Services.Issue
+﻿using MaelstromPlatform.API.Person;
+using MaelstromPlatform.API.Team;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations;
+
+namespace MaelstromPlatform.API.Issue
 {
-    public class IssueModel
+    public class IssueForGetByIdDto
     {
         public Guid SysId { get; set; }
         public string Identifier { get; set; }
+        public Guid OrganizationId { get; set; }
         public string SummaryBrief { get; set; }
         public string SummaryLong { get; set; }
         public DateTime Origin { get; set; }
@@ -26,5 +32,6 @@
         public Guid ReportedByPrimaryPersonSysId { get; set; }
         public DateTime FoundOn { get; set; }
         public DateTime ReportedOn { get; set; }
+        public ICollection<IssueApprovalEntity> Approvals { get; set; } = new List<IssueApprovalEntity>();
     }
 }

--- a/src/MaelstromPlatform.API/Issue/IssueProfile.cs
+++ b/src/MaelstromPlatform.API/Issue/IssueProfile.cs
@@ -7,6 +7,7 @@ namespace MaelstromPlatform.API.Issue
         public IssueProfile()
         {
             CreateMap<IssueEntity, IssueForGetAllDto>().ReverseMap();
+            CreateMap<IssueEntity, IssueForGetByIdDto>().ReverseMap();
         }
     }
 }

--- a/src/MaelstromPlatform.API/Issue/IssueRepository.cs
+++ b/src/MaelstromPlatform.API/Issue/IssueRepository.cs
@@ -17,6 +17,11 @@ namespace MaelstromPlatform.API.Issue
             return await _context.Issues.ToListAsync();
         }
 
+        public async Task<IssueEntity> GetIssueByIdAsync(Guid id)
+        {
+            return await _context.Issues.Where(i => i.SysId == id).FirstOrDefaultAsync();
+        }
+
         public async Task<bool> SaveChangesAsync()
         {
             return (await _context.SaveChangesAsync() >= 0);

--- a/src/MaelstromPlatform.API/Issue/IssuesController.cs
+++ b/src/MaelstromPlatform.API/Issue/IssuesController.cs
@@ -23,5 +23,13 @@ namespace MaelstromPlatform.API.Issue
 
             return Ok(_mapper.Map<IEnumerable<IssueForGetAllDto>>(issueEntities));
         }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<IssueForGetByIdDto>> GetIssueByIdAsync(Guid id)
+        {
+            var issueEntities = await _issueRepository.GetIssueByIdAsync(id);
+
+            return Ok(_mapper.Map<IssueForGetByIdDto>(issueEntities));
+        }
     }
 }

--- a/src/MaelstromPlatform.UI/Components/Common/MaelstromDataGrid.razor
+++ b/src/MaelstromPlatform.UI/Components/Common/MaelstromDataGrid.razor
@@ -1,4 +1,5 @@
 ﻿@using MaelstromPlatform.UI.Components.Common
+@inject NavigationManager Navigation
 
 <RadzenDataGrid AllowFiltering="true"
                 AllowColumnResize="true"
@@ -11,11 +12,16 @@
                 ShowPagingSummary="true"
                 Data="@Data"
                 SelectionMode="DataGridSelectionMode.Single"
-                >
+                TItem="object">
     <Columns>
+        <RadzenDataGridColumn Context="obj" Filterable="false" Sortable="false" TextAlign="TextAlign.Center" Frozen="false">
+            <Template Context="obj">
+                <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Primary" Variant="Variant.Flat" Size="ButtonSize.Medium" Click="@(args => ViewObject(obj))" @onclick:stopPropagation="true"></RadzenButton>
+            </Template>
+        </RadzenDataGridColumn>
         @foreach (var column in ColumnData)
         {
-            <RadzenDataGridColumn Property="@column.Property" Title="@column.Title" Frozen="@column.Frozen" Width="@column.Width.ToString()" TextAlign="@column.TextAlign" />
+            <RadzenDataGridColumn Property="@column.Property" Title="@column.Title" Frozen="@column.Frozen" Width="@column.Width.ToString()" TextAlign="@column.TextAlign"/>
         }
     </Columns>
 </RadzenDataGrid>
@@ -25,4 +31,9 @@
     [Parameter] public List<MaelstromDataGridColumn> ColumnData { get; set; } = new();
 
     private ushort PageSize { get; set; } = 10;
+
+    private void ViewObject(object obj)
+    {
+        Navigation.NavigateTo("issue/1");
+    }
 }

--- a/src/MaelstromPlatform.UI/Components/Services/Issue/IssueBrowse.razor
+++ b/src/MaelstromPlatform.UI/Components/Services/Issue/IssueBrowse.razor
@@ -9,14 +9,38 @@
     else
     {
         <RadzenText TextStyle="TextStyle.DisplayH4">Browse Issues</RadzenText>
-        <MaelstromDataGrid ColumnData="@Columns" Data="@Data" />
-        <button @onclick="HandleIssueItem">Issue 1 Item</button>
+        <RadzenDataGrid AllowFiltering="true"
+                        AllowColumnResize="true"
+                        AllowAlternatingRows="true"
+                        FilterMode="FilterMode.Advanced"
+                        AllowSorting="true"
+                        PageSize="@PageSize"
+                        AllowPaging="true"
+                        PagerHorizontalAlign="HorizontalAlign.Left"
+                        ShowPagingSummary="true"
+                        Data="@Data"
+                        SelectionMode="DataGridSelectionMode.Single"
+                        TItem="IssueModel">
+            <Columns>
+                <RadzenDataGridColumn Context="issue" Filterable="false" Sortable="false" TextAlign="TextAlign.Center" Frozen="false">
+                    <Template Context="issue">
+                        <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Primary" Variant="Variant.Flat" Size="ButtonSize.Medium" Click="@(args => ViewObject(issue))" @onclick:stopPropagation="true"></RadzenButton>
+                    </Template>
+                </RadzenDataGridColumn>
+                @foreach (var column in Columns)
+                {
+                    <RadzenDataGridColumn Property="@column.Property" Title="@column.Title" Frozen="@column.Frozen" Width="@column.Width.ToString()" TextAlign="@column.TextAlign"/>
+                }
+            </Columns>
+        </RadzenDataGrid>
     }
 </RadzenStack>
 
 @code {
     private bool IsLoading { get; set; } = true;
-    private List<object> Data { get; set; } = new();
+    private List<IssueModel> Data { get; set; } = new();
+
+    private ushort PageSize { get; set; } = 1;
 
     private List<MaelstromDataGridColumn> Columns =
     [
@@ -24,10 +48,10 @@
         new MaelstromDataGridColumn() { Property = "SummaryBrief", Title = "Summary", Filterable = true, Frozen = false, TextAlign = TextAlign.Left, Width = 300 }
     ];
 
-    private async Task<List<object>> GetItemDetails()
+    private async Task<List<IssueModel>> GetItemDetails()
     {
         var result = await Http.GetFromJsonAsync<List<IssueModel>>($"/api/issues") ?? new List<IssueModel>();
-        return (result.Cast<object>().ToList());
+        return result;
     }
 
     protected override async Task OnParametersSetAsync()
@@ -37,8 +61,8 @@
         IsLoading = false;
     }
 
-    private void HandleIssueItem()
+    private void ViewObject(IssueModel issue)
     {
-        Navigation.NavigateTo("issue/1");
+        Navigation.NavigateTo($"issue/{issue.SysId}");
     }
 }

--- a/src/MaelstromPlatform.UI/Components/Services/Issue/Item/IssueItemDashboard.razor
+++ b/src/MaelstromPlatform.UI/Components/Services/Issue/Item/IssueItemDashboard.razor
@@ -1,6 +1,35 @@
-﻿<RadzenText TextStyle="TextStyle.DisplayH4">Issue Item Dashboard</RadzenText>
-<RadzenText TextStyle="TextStyle.DisplayH4">@Org</RadzenText>
+﻿@inject HttpClient Http
+
+<RadzenStack Orientation="Orientation.Vertical" JustifyContent="JustifyContent.Start" Wrap="FlexWrap.NoWrap">
+    @if (IsLoading)
+    {
+        <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Primary" Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate" />
+    }
+    else
+    {
+        <RadzenText TextStyle="TextStyle.DisplayH4">Issue @Identifier Dashboard</RadzenText>
+    }
+</RadzenStack>
 
 @code {
-    [Parameter] public string Org { get; set; }
+    [Parameter] public Guid Id { get; set; }
+
+    private bool IsLoading { get; set; } = true;
+
+    private IssueModel IssueData = new();
+    private string Identifier { get; set; }
+
+    private async Task<IssueModel> GetItemDetails()
+    {
+        var result = await Http.GetFromJsonAsync<IssueModel>($"/api/issues/{Id}") ?? new IssueModel();
+        return result;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        IssueData = await GetItemDetails();
+        Identifier = IssueData.Identifier;
+        await base.OnParametersSetAsync();
+        IsLoading = false;
+    }
 }

--- a/src/MaelstromPlatform.UI/Components/Services/Issue/Item/IssueItemProfile.razor
+++ b/src/MaelstromPlatform.UI/Components/Services/Issue/Item/IssueItemProfile.razor
@@ -1,5 +1,35 @@
-﻿<RadzenText TextStyle="TextStyle.DisplayH4">Issue Item Profile</RadzenText>
+﻿@inject HttpClient Http
+
+<RadzenStack Orientation="Orientation.Vertical" JustifyContent="JustifyContent.Start" Wrap="FlexWrap.NoWrap">
+    @if (IsLoading)
+    {
+        <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Primary" Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate" />
+    }
+    else
+    {
+        <RadzenText TextStyle="TextStyle.DisplayH4">Issue @Identifier Profile</RadzenText>
+    }
+</RadzenStack>
 
 @code {
+    [Parameter] public Guid Id { get; set; }
 
+    private bool IsLoading { get; set; } = true;
+
+    private IssueModel IssueData = new();
+    private string Identifier { get; set; }
+
+    private async Task<IssueModel> GetItemDetails()
+    {
+        var result = await Http.GetFromJsonAsync<IssueModel>($"/api/issues/{Id}") ?? new IssueModel();
+        return result;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        IssueData = await GetItemDetails();
+        Identifier = IssueData.Identifier;
+        await base.OnParametersSetAsync();
+        IsLoading = false;
+    }
 }

--- a/src/MaelstromPlatform.UI/Pages/Issue/Item/IssueItemDashboardPage.razor
+++ b/src/MaelstromPlatform.UI/Pages/Issue/Item/IssueItemDashboardPage.razor
@@ -1,26 +1,25 @@
-﻿@page "/issue/1"
+﻿@page "/issue/{Id:guid}"
 @using MaelstromPlatform.UI.Components.Services.Issue.Item
 @layout ServiceItemShell
 
-<IssueItemDashboard Org="@Org"/>
+<IssueItemDashboard Id="@Id" />
 
 @code {
     [CascadingParameter] public MaelstromState GlobalState { get; set; }
+    [Parameter] public Guid Id { get; set; }
 
     private string Org { get; set; }
 
     protected override void OnInitialized()
     {
-        Org = GlobalState.Organization;
+        Items.Add(new MaelstromMenuItem { Caption = "Dashboard", Location = $"issue/{Id}" });
+        Items.Add(new MaelstromMenuItem { Caption = "Profile", Location = $"issue/{Id}/profile" });
 
+        Org = GlobalState.Organization;
         GlobalState.ServiceItemMenuItems = Items;
         GlobalState.ActiveService = "Issue";
         GlobalState.StateChanged.Invoke();
     }
 
-    private static readonly List<MaelstromMenuItem> Items =
-    [
-        new MaelstromMenuItem { Caption = "Dashboard", Location = "issue/1" },
-        new MaelstromMenuItem { Caption = "Profile", Location = "issue/1/profile" }
-    ];
+    private List<MaelstromMenuItem> Items { get; set; } = new();
 }

--- a/src/MaelstromPlatform.UI/Pages/Issue/Item/IssueItemProfilePage.razor
+++ b/src/MaelstromPlatform.UI/Pages/Issue/Item/IssueItemProfilePage.razor
@@ -1,9 +1,9 @@
-﻿@page "/issue/1/profile"
+﻿@page "/issue/{Id:guid}/profile"
 @using MaelstromPlatform.UI.Components.Services.Issue.Item
 @layout ServiceItemShell
 
-<IssueItemProfile/>
+<IssueItemProfile Id="@Id" />
 
 @code {
-
+    [Parameter] public Guid Id { get; set; }
 }


### PR DESCRIPTION
Also setup IssueItemDashboard and IssueItemProfile components to use
Id parameter from the IssueBrowse component and load from API the
selected issue in the IssueBrowse component. Created API endpoint to
get just one issue.

This adds technical debt as a generic data grid was not finished, but
I'm willing to accept this in the spirit of getting many other parts
of the Maelstrom Platform implemented sooner than later.

Fixes #44.